### PR TITLE
Refine SMA parsing defaults and grouped builds

### DIFF
--- a/electron/defaults.cjs
+++ b/electron/defaults.cjs
@@ -1,0 +1,86 @@
+const ZP508a_DEFAULTS = Object.freeze({
+  zombie_class: { health: 2000, speed: 250, gravity: 1.0, knockback: 1.0 },
+  human_class: { health: 100, speed: 240, gravity: 1.0, armor: 0 },
+  special_zombie_class: { health: 2000, speed: 250, gravity: 1.0, knockback: 1.0 },
+  special_human_class: { health: 100, speed: 240, gravity: 1.0, armor: 0 }
+})
+
+function createDefaultTracker() {
+  return {
+    applied: new Set(),
+    overridden: new Set()
+  }
+}
+
+function ensureDefaultTracker(entity) {
+  if (!entity || typeof entity !== 'object') return createDefaultTracker()
+  if (!entity.meta || typeof entity.meta !== 'object') entity.meta = {}
+  const tracker = entity.meta.defaultTracker
+  if (
+    tracker &&
+    tracker.applied instanceof Set &&
+    tracker.overridden instanceof Set
+  ) {
+    return tracker
+  }
+  const fresh = createDefaultTracker()
+  entity.meta.defaultTracker = fresh
+  return fresh
+}
+
+function applyDefaultsToEntity(entity) {
+  if (!entity || typeof entity !== 'object') return []
+  if (!entity.stats || typeof entity.stats !== 'object') entity.stats = {}
+  const defaults = ZP508a_DEFAULTS[entity.type]
+  if (!defaults) return []
+  const tracker = ensureDefaultTracker(entity)
+  const applied = []
+  for (const [field, value] of Object.entries(defaults)) {
+    const current = entity.stats[field]
+    if (current === undefined || current === null || Number.isNaN(current)) {
+      entity.stats[field] = value
+      tracker.applied.add(field)
+      tracker.overridden.delete(field)
+      applied.push(field)
+    }
+  }
+  return applied
+}
+
+function markDefaultOverridden(entity, field) {
+  if (!entity || !field) return false
+  const tracker = ensureDefaultTracker(entity)
+  if (tracker.applied.has(field)) {
+    tracker.applied.delete(field)
+    tracker.overridden.add(field)
+    return true
+  }
+  return false
+}
+
+function finalizeDefaultMeta(entity) {
+  if (!entity || !entity.meta) return
+  const tracker = entity.meta.defaultTracker
+  if (!tracker) return
+  const applied = tracker.applied instanceof Set ? Array.from(tracker.applied) : []
+  const overridden = tracker.overridden instanceof Set ? Array.from(tracker.overridden) : []
+  if (applied.length || overridden.length) {
+    if (!Array.isArray(entity.meta.extraCalls)) entity.meta.extraCalls = []
+    if (applied.length) {
+      entity.meta.extraCalls.push({ type: 'defaultApplied', fields: applied })
+    }
+    if (overridden.length) {
+      entity.meta.extraCalls.push({ type: 'defaultOverridden', fields: overridden })
+    }
+  }
+  delete entity.meta.defaultTracker
+}
+
+module.exports = {
+  ZP508a_DEFAULTS,
+  createDefaultTracker,
+  ensureDefaultTracker,
+  applyDefaultsToEntity,
+  markDefaultOverridden,
+  finalizeDefaultMeta
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,8 +1,8 @@
 export type ZPType = 
   | 'human_class'
   | 'zombie_class'
-  | 'human_special'
-  | 'zombie_special'
+  | 'special_human_class'
+  | 'special_zombie_class'
   | 'mode'
   | 'weapon'
   | 'shop_item'
@@ -48,8 +48,8 @@ export interface ShopItemStats {
 export type ZPItem =
   | (BaseItem & { type: 'zombie_class'; stats: ZombieStats })
   | (BaseItem & { type: 'human_class'; stats: HumanStats })
-  | (BaseItem & { type: 'zombie_special'; stats: ZombieStats })
-  | (BaseItem & { type: 'human_special'; stats: HumanStats })
+  | (BaseItem & { type: 'special_zombie_class'; stats: ZombieStats })
+  | (BaseItem & { type: 'special_human_class'; stats: HumanStats })
   | (BaseItem & { type: 'weapon'; stats: WeaponStats })
   | (BaseItem & { type: 'shop_item'; stats: ShopItemStats })
   | (BaseItem & { type: 'mode' | 'system'; stats: Record<string, any> })

--- a/src/common/zpUtils.ts
+++ b/src/common/zpUtils.ts
@@ -7,11 +7,11 @@ import type {
   ShopItemStats
 } from './types'
 
-const CLASS_DEFAULTS: Record<'zombie_class' | 'human_class' | 'zombie_special' | 'human_special', ZombieStats | HumanStats> = {
+const CLASS_DEFAULTS: Record<'zombie_class' | 'human_class' | 'special_zombie_class' | 'special_human_class', ZombieStats | HumanStats> = {
   zombie_class: { health: 2000, speed: 250, gravity: 1.0, knockback: 1.0 },
   human_class: { health: 100, speed: 240, armor: 0, base_damage: 1.0 },
-  zombie_special: { health: 2000, speed: 250, gravity: 1.0, knockback: 1.0 },
-  human_special: { health: 100, speed: 240, armor: 0, base_damage: 1.0 }
+  special_zombie_class: { health: 2000, speed: 250, gravity: 1.0, knockback: 1.0 },
+  special_human_class: { health: 100, speed: 240, armor: 0, base_damage: 1.0 }
 }
 
 const WEAPON_DEFAULTS: WeaponStats = { damage: 0, clip_capacity: 0, fire_rate: 0, reload_time: 0, cost: 0 }
@@ -20,10 +20,10 @@ const SHOP_DEFAULTS: ShopItemStats = { cost: 0, team: 0, unlimited: 0 }
 export function getDefaultStats(type: ZPType): ZombieStats | HumanStats | WeaponStats | ShopItemStats | Record<string, any> {
   switch (type) {
     case 'zombie_class':
-    case 'zombie_special':
+    case 'special_zombie_class':
       return { ...(CLASS_DEFAULTS[type] as ZombieStats) }
     case 'human_class':
-    case 'human_special':
+    case 'special_human_class':
       return { ...(CLASS_DEFAULTS[type] as HumanStats) }
     case 'weapon':
       return { ...WEAPON_DEFAULTS }
@@ -64,9 +64,9 @@ export function sanitizePathsForType(
     return { models: [], sounds: [], sprites: [] }
   }
 
-  if (['human_class', 'zombie_class', 'human_special', 'zombie_special'].includes(type)) {
+  if (['human_class', 'zombie_class', 'special_human_class', 'special_zombie_class'].includes(type)) {
     const filteredModels = base.models.filter((m) => !m.toLowerCase().endsWith('.spr'))
-    return { models: filteredModels, sounds: [], sprites: [] }
+    return { models: filteredModels, sounds: base.sounds, sprites: base.sprites }
   }
 
   return base

--- a/src/components/EditModal.tsx
+++ b/src/components/EditModal.tsx
@@ -14,7 +14,7 @@ interface EditModalProps {
   onSave: (item: ZPItem) => void
 }
 
-const CLASS_TYPES = new Set(['human_class', 'zombie_class', 'human_special', 'zombie_special'])
+const CLASS_TYPES = new Set(['human_class', 'zombie_class', 'special_human_class', 'special_zombie_class'])
 
 function asStringArray(value: unknown): string[] {
   if (Array.isArray(value)) return value.map((entry) => String(entry))
@@ -107,7 +107,7 @@ export default function EditModal({ item, onClose, onSave }: EditModalProps) {
   const renderSpecificFields = () => {
     switch (draft.type) {
       case 'zombie_class':
-      case 'zombie_special': {
+      case 'special_zombie_class': {
         const zStats = draft.stats as ZombieStats
         return (
           <>
@@ -157,7 +157,7 @@ export default function EditModal({ item, onClose, onSave }: EditModalProps) {
         )
       }
       case 'human_class':
-      case 'human_special': {
+      case 'special_human_class': {
         const hStats = draft.stats as HumanStats
         return (
           <>
@@ -381,8 +381,8 @@ export default function EditModal({ item, onClose, onSave }: EditModalProps) {
             <select value={draft.type} onChange={(e) => handleTypeChange(e.target.value as ZPItem['type'])}>
               <option value="human_class">Human Class</option>
               <option value="zombie_class">Zombie Class</option>
-              <option value="human_special">Human Special</option>
-              <option value="zombie_special">Zombie Special</option>
+              <option value="special_human_class">Human Special</option>
+              <option value="special_zombie_class">Zombie Special</option>
               <option value="mode">Mode</option>
               <option value="weapon">Weapon</option>
               <option value="shop_item">Shop Item</option>

--- a/src/renderer/ui/App.tsx
+++ b/src/renderer/ui/App.tsx
@@ -8,8 +8,8 @@ declare global { interface Window { zpb: any } }
 const SECTIONS: { key: ZPType | "model" | "sprite" | "sound", label: string }[] = [
   { key: 'human_class', label: 'Clases Humano' },
   { key: 'zombie_class', label: 'Clases Zombie' },
-  { key: 'human_special', label: 'Clases especiales Humano' },
-  { key: 'zombie_special', label: 'Clases especiales Zombie' },
+  { key: 'special_human_class', label: 'Clases especiales Humano' },
+  { key: 'special_zombie_class', label: 'Clases especiales Zombie' },
   { key: 'mode', label: 'Modos' },
   { key: 'weapon', label: 'Armas' },
   { key: 'shop_item', label: 'Objetos Extras' },
@@ -39,10 +39,10 @@ const emptyItem = (type: ZPType): ZPItem => {
       return { ...base, type: 'zombie_class', stats: getDefaultStats('zombie_class') as ZombieStats }
     case 'human_class':
       return { ...base, type: 'human_class', stats: getDefaultStats('human_class') as HumanStats }
-    case 'zombie_special':
-      return { ...base, type: 'zombie_special', stats: getDefaultStats('zombie_special') as ZombieStats }
-    case 'human_special':
-      return { ...base, type: 'human_special', stats: getDefaultStats('human_special') as HumanStats }
+    case 'special_zombie_class':
+      return { ...base, type: 'special_zombie_class', stats: getDefaultStats('special_zombie_class') as ZombieStats }
+    case 'special_human_class':
+      return { ...base, type: 'special_human_class', stats: getDefaultStats('special_human_class') as HumanStats }
     case 'weapon':
       return { ...base, type: 'weapon', stats: getDefaultStats('weapon') as WeaponStats }
     case 'shop_item':


### PR DESCRIPTION
## Summary
- add a dedicated `defaults.cjs` helper that centralizes ZP 5.0.8a stat defaults and records which fields were applied or overridden for each entity
- expand the SMA parser to resolve multi-line defines/const assignments, normalize aliases across 4.3/5.0.8a, track resolved-from metadata, and improve supplemental routing/conflict warnings
- update the Electron build pipeline to apply the new defaults, group generated SMA output per type with resource dedupe/headers, and reuse parser normalization utilities

## Testing
- npm run build
- npm run dev *(fails: missing libatk-1.0.so.0 in Electron runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb6300be483229786275246d14b05