### PR TITLE
Enhance SMA parsing with runtime awareness and enriched metadata

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -817,15 +817,15 @@ function generateGroupedSMA(type, items) {
   }
 
   const headerLines = [
-    '// Auto generado por ZP Builder UI (ZP 5.0.8a)',
+    `// Archivo generado por ZP Builder UI - ${pluginLabel}`,
     `// Fecha: ${now}`,
-    `// Entidades: ${entries.length}`
+    `// Entidades: ${entries.length}`,
+    '// Warnings:'
   ]
   if (warnings.length) {
-    headerLines.push('// Warnings detectados:')
     for (const warn of warnings) headerLines.push(`// - ${warn}`)
   } else {
-    headerLines.push('// Warnings detectados: ninguno')
+    headerLines.push('// - ninguno')
   }
 
   const pluginInit = `public plugin_init() { register_plugin("${escapePawnString(`ZPBuilder - ${pluginLabel}`)}", "0.4.0", "ZPBuilder"); }`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev:electron": "wait-on tcp:5173 && electron .",
     "build": "vite build && electron-builder",
     "start": "electron .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "smoke": "node scripts/smoke-parse.js"
   },
   "dependencies": {
     "electron-store": "^8.1.0",

--- a/scripts/smoke-parse.js
+++ b/scripts/smoke-parse.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { parseSMAEntities } = require('../electron/smaParser.cjs')
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const projectRoot = path.resolve(__dirname, '..')
+const inputDir = path.join(projectRoot, 'input')
+
+function walk(dir) {
+  const results = []
+  if (!fs.existsSync(dir)) return results
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const resolved = path.join(dir, entry.name)
+    if (entry.isDirectory()) results.push(...walk(resolved))
+    else if (entry.isFile() && entry.name.toLowerCase().endsWith('.sma')) results.push(resolved)
+  }
+  return results
+}
+
+function collectWarnings(entities) {
+  const warnings = []
+  for (const entity of entities) {
+    const metaWarnings = Array.isArray(entity?.meta?.warnings) ? entity.meta.warnings : []
+    for (const warning of metaWarnings) {
+      const text = String(warning || '').trim()
+      if (text) warnings.push(text)
+    }
+  }
+  return warnings
+}
+
+const files = walk(inputDir)
+const totals = new Map()
+const warnings = []
+const pseudoExamples = []
+const menuExamples = []
+const extraCallExamples = []
+let unresolvedBaseWarnings = 0
+
+for (const filePath of files) {
+  const raw = fs.readFileSync(filePath, 'utf-8')
+  const entities = parseSMAEntities(filePath, raw)
+  for (const entity of entities) {
+    const type = entity?.type || 'unknown'
+    totals.set(type, (totals.get(type) || 0) + 1)
+    if (entity?.meta?.source === 'pseudo' && pseudoExamples.length < 5) {
+      pseudoExamples.push({
+        name: entity.name,
+        file: path.relative(projectRoot, filePath),
+        line: entity?.meta?.registerLine
+      })
+    }
+    if (entity?.meta?.source === 'menu-array' && menuExamples.length < 5) {
+      menuExamples.push({
+        name: entity.name,
+        file: path.relative(projectRoot, filePath),
+        base: entity?.meta?.menuBase,
+        index: entity?.meta?.menuIndex
+      })
+    }
+    const extraCalls = Array.isArray(entity?.meta?.extraCalls) ? entity.meta.extraCalls : []
+    for (const call of extraCalls) {
+      if (!call || typeof call !== 'object') continue
+      if (!call.fn) continue
+      if (extraCallExamples.length >= 5) break
+      extraCallExamples.push({
+        entity: entity.name,
+        type,
+        fn: call.fn,
+        kind: call.kind,
+        resolved: Boolean(call.resolved),
+        resolvedFrom: Array.isArray(call.resolvedFrom) ? call.resolvedFrom : [],
+        line: call.line
+      })
+    }
+  }
+  const entityWarnings = collectWarnings(entities)
+  warnings.push(...entityWarnings)
+  unresolvedBaseWarnings += entityWarnings.filter(msg => msg.includes('No se encontró entidad base')).length
+}
+
+console.log('Resumen de entidades escaneadas:')
+for (const [type, count] of totals.entries()) {
+  console.log(` - ${type}: ${count}`)
+}
+console.log('')
+console.log(`Warnings totales: ${warnings.length}`)
+console.log(`Warnings "sin base": ${unresolvedBaseWarnings}`)
+console.log('')
+
+if (pseudoExamples.length) {
+  console.log('Ejemplos de pseudo-clases detectadas:')
+  for (const example of pseudoExamples) {
+    console.log(` - ${example.name} (${example.file}:${example.line ?? '?'})`)
+  }
+  console.log('')
+} else {
+  console.log('No se detectaron pseudo-clases.\n')
+}
+
+if (menuExamples.length) {
+  console.log('Ejemplos de entidades definidas en arrays/menús:')
+  for (const example of menuExamples) {
+    console.log(` - ${example.name} [${example.base}] (índice ${example.index}) en ${example.file}`)
+  }
+  console.log('')
+} else {
+  console.log('No se detectaron entidades de menús basadas en arrays.\n')
+}
+
+if (extraCallExamples.length) {
+  console.log('Ejemplos de extraCalls enriquecidos:')
+  for (const call of extraCallExamples) {
+    const resolvedFrom = call.resolvedFrom.length ? call.resolvedFrom.join(', ') : 'sin fuentes'
+    console.log(` - ${call.fn} → ${call.kind || 'desconocido'} (${call.resolved ? 'resuelto' : 'fallback'}) en ${call.entity} [${call.type}] :: fuentes=${resolvedFrom}`)
+  }
+  console.log('')
+} else {
+  console.log('No se registraron extraCalls enriquecidos.\n')
+}


### PR DESCRIPTION
## Summary
- capture const-based class definitions without semicolons and treat unresolved identifiers as runtime values to avoid noisy parser warnings while recording fallback sources
- enrich supplemental call tracking by emitting resolved arguments, origins, and dynamic flags for stats and resources, and apply defaults when fallback values are encountered
- extend the smoke parser to report extra call examples alongside existing pseudo-class and array coverage for easier validation

## Testing
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ce34376ecc83228336df645a8580c8