### PR TITLE
Implement resource scanning and smoke tooling

### DIFF
--- a/scripts/smoke-parse.js
+++ b/scripts/smoke-parse.js
@@ -1,3 +1,198 @@
 #!/usr/bin/env node
-console.log('Smoke test placeholder')
-console.log('TODO: contar entidades, mostrar ejemplos de pseudo-clases, abilities y extraCalls')
+
+import fs from 'fs/promises'
+import path from 'path'
+import process from 'process'
+
+import { scanResources } from '../src/utils/file-scanner.js'
+
+const parserModule = await import('../electron/smaParser.cjs')
+const { parseSMAEntities } = parserModule
+
+function formatCountTable(counts) {
+  const entries = Array.from(counts.entries())
+  const maxLabel = entries.reduce((acc, [label]) => Math.max(acc, label.length), 0)
+  return entries
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([label, count]) => `${label.padEnd(maxLabel, ' ')} : ${String(count).padStart(3, ' ')}`)
+    .join('\n')
+}
+
+async function walkSmaFiles(baseDir) {
+  const files = []
+  async function walk(dir) {
+    let entries
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true })
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return
+      throw err
+    }
+    for (const entry of entries) {
+      const abs = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(abs)
+        continue
+      }
+      if (!entry.isFile()) continue
+      if (!entry.name.toLowerCase().endsWith('.sma')) continue
+      files.push(abs)
+    }
+  }
+
+  await walk(baseDir)
+  return files
+}
+
+function collectEntityCounts(entities) {
+  const counts = new Map()
+  for (const entity of entities) {
+    const type = entity?.type || 'unknown'
+    counts.set(type, (counts.get(type) || 0) + 1)
+  }
+  return counts
+}
+
+function collectPseudoNames(entities, limit = 10) {
+  const names = []
+  for (const entity of entities) {
+    if (entity?.meta?.source !== 'pseudo') continue
+    if (entity?.name) names.push(entity.name)
+  }
+  names.sort((a, b) => a.localeCompare(b))
+  return names.slice(0, limit)
+}
+
+function collectSupplementalExamples(entities, limit = 5) {
+  const examples = []
+  for (const entity of entities) {
+    if (!Array.isArray(entity?.meta?.extraCalls)) continue
+    for (const call of entity.meta.extraCalls) {
+      if (!call || typeof call !== 'object' || !call.fn) continue
+      const kind = call.kind || call.fn
+      const expanded = Array.isArray(call.expanded) ? call.expanded : call.values || []
+      examples.push({
+        entity: entity.name || entity.meta?.normalizedName || '(sin nombre)',
+        type: entity.type,
+        fn: call.fn,
+        kind,
+        expanded: expanded.slice(0, 3)
+      })
+      if (examples.length >= limit) return examples
+    }
+  }
+  return examples
+}
+
+function collectExtraCallSamples(entities, limit = 5) {
+  const samples = []
+  for (const entity of entities) {
+    if (!Array.isArray(entity?.meta?.extraCalls)) continue
+    for (const call of entity.meta.extraCalls) {
+      if (!call || typeof call !== 'object' || !call.fn) continue
+      samples.push({
+        entity: entity.name || entity.meta?.normalizedName || '(sin nombre)',
+        fn: call.fn,
+        resolved: Boolean(call.resolved),
+        dynamic: Boolean(call.dynamic),
+        resolvedFrom: Array.isArray(call.resolvedFrom) ? call.resolvedFrom : [],
+        args: Array.isArray(call.args) ? call.args.slice(0, 3) : []
+      })
+      if (samples.length >= limit) return samples
+    }
+  }
+  return samples
+}
+
+function gatherResourceReferences(entities) {
+  const refs = { models: new Set(), sprites: new Set(), sounds: new Set() }
+  for (const entity of entities) {
+    const paths = entity?.paths || {}
+    for (const model of paths.models || []) refs.models.add(model.toLowerCase())
+    for (const claw of paths.claws || []) refs.models.add(claw.toLowerCase())
+    for (const sprite of paths.sprites || []) refs.sprites.add(sprite.toLowerCase())
+    for (const sound of paths.sounds || []) refs.sounds.add(sound.toLowerCase())
+  }
+  return refs
+}
+
+function computeMissingResources(references, available, limit = 10) {
+  const missing = {}
+  for (const kind of Object.keys(references)) {
+    const refSet = references[kind]
+    const availableSet = new Set((available[kind] || []).map((v) => v.toLowerCase()))
+    const diff = []
+    for (const value of refSet) {
+      if (!availableSet.has(value)) diff.push(value)
+    }
+    diff.sort((a, b) => a.localeCompare(b))
+    missing[kind] = diff.slice(0, limit)
+  }
+  return missing
+}
+
+async function main() {
+  const inputDir = path.resolve(process.cwd(), 'input')
+  const files = await walkSmaFiles(inputDir)
+  if (!files.length) {
+    console.warn('No se encontraron archivos .sma en input/. Finalizando smoke test.')
+    return
+  }
+
+  const entities = []
+  for (const file of files) {
+    const raw = await fs.readFile(file, 'utf8')
+    try {
+      const parsed = parseSMAEntities(file, raw)
+      entities.push(...parsed)
+    } catch (err) {
+      console.error(`Error al parsear ${path.relative(inputDir, file)}:`, err.message)
+    }
+  }
+
+  const counts = collectEntityCounts(entities)
+  console.log('=== Conteo por tipo ===')
+  console.log(formatCountTable(counts))
+
+  const pseudoNames = collectPseudoNames(entities)
+  console.log('\n=== Pseudo-clases humanas detectadas ===')
+  pseudoNames.forEach((name, idx) => console.log(`${String(idx + 1).padStart(2, '0')}. ${name}`))
+  if (!pseudoNames.length) console.log('Sin pseudo-clases detectadas')
+
+  const supplemental = collectSupplementalExamples(entities)
+  console.log('\n=== Ejemplos de llamadas suplementarias ===')
+  if (!supplemental.length) console.log('Sin llamadas suplementarias detectadas')
+  else supplemental.forEach((entry, idx) => {
+    console.log(`${idx + 1}. ${entry.fn} -> ${entry.kind} [${entry.type}] ${entry.entity}`)
+    if (entry.expanded.length) {
+      console.log(`   Recursos: ${entry.expanded.join(', ')}`)
+    }
+  })
+
+  const extraSamples = collectExtraCallSamples(entities)
+  console.log('\n=== extraCalls (auditoría rápida) ===')
+  if (!extraSamples.length) console.log('Sin extraCalls registrados')
+  else extraSamples.forEach((sample, idx) => {
+    const resolvedFrom = sample.resolvedFrom.length ? ` [${sample.resolvedFrom.join(', ')}]` : ''
+    console.log(`${idx + 1}. ${sample.fn} (${sample.entity}) -> resolved=${sample.resolved} dynamic=${sample.dynamic}${resolvedFrom}`)
+    if (sample.args.length) console.log(`   args: ${sample.args.join(', ')}`)
+  })
+
+  const available = await scanResources(inputDir)
+  console.log('\n=== Recursos disponibles ===')
+  console.log(`Modelos: ${available.models.length}`)
+  console.log(`Sprites: ${available.sprites.length}`)
+  console.log(`Sonidos: ${available.sounds.length}`)
+
+  const references = gatherResourceReferences(entities)
+  const missing = computeMissingResources(references, available)
+  console.log('\n=== Referencias ausentes (top 10) ===')
+  for (const [kind, list] of Object.entries(missing)) {
+    console.log(`- ${kind}: ${list.length ? list.join(', ') : 'completo'}`)
+  }
+}
+
+main().catch((err) => {
+  console.error('Smoke test falló:', err)
+  process.exitCode = 1
+})

--- a/src/parser/sma-parser.js
+++ b/src/parser/sma-parser.js
@@ -1,18 +1,45 @@
-console.log('[parser] SMA parser stubs loaded')
+import parserModule from '../../electron/smaParser.cjs'
 
-/**
- * Base entity shape for parser results.
- * @returns {{
- *   type: string,
- *   name: string,
- *   stats: Record<string, any>,
- *   paths: { models: string[], claws: string[], sprites: string[], sounds: string[] },
- *   abilities: any[],
- *   meta: { filePath: string, line: number, origin: string, extraCalls: any[], resolvedFrom: any[] }
- * }}
- */
+const { parseSMAEntities, normalizeName, normalizePath } = parserModule
+
+export { parseSMAEntities, normalizeName, normalizePath }
+
+const SPRITE_REGEX = /"([^"\n]+\.spr)"/gi
+const SOUND_REGEX = /"([^"\n]+\.(?:wav|mp3))"/gi
+
+const ABILITY_PATTERNS = [
+  { regex: /set_user_health\s*\([^,]+,\s*([^\)]+)\)/gi, effect: 'heal', fn: 'set_user_health' },
+  { regex: /cs_set_user_armor\s*\([^,]+,\s*([^,\)]+)[^)]*\)/gi, effect: 'armor_boost', fn: 'cs_set_user_armor' },
+  { regex: /set_user_maxspeed\s*\([^,]+,\s*([^\)]+)\)/gi, effect: 'speed_boost', fn: 'set_user_maxspeed' },
+  { regex: /set_user_gravity\s*\([^,]+,\s*([^\)]+)\)/gi, effect: 'low_gravity', fn: 'set_user_gravity' },
+  { regex: /set_user_rendering\s*\(/gi, effect: 'invisibility', fn: 'set_user_rendering', capture: false },
+  { regex: /pev_\s*\(\s*id\s*,\s*pev_rendermode/gi, effect: 'invisibility', fn: 'pev_rendermode', capture: false }
+]
+
+function ensureMeta(entity) {
+  if (!entity.meta) entity.meta = { extraCalls: [], resolvedFrom: [] }
+  if (!Array.isArray(entity.meta.extraCalls)) entity.meta.extraCalls = []
+  return entity.meta
+}
+
+function ensureAbilities(entity) {
+  if (!Array.isArray(entity.abilities)) entity.abilities = []
+  return entity.abilities
+}
+
+function ensurePathArray(entity, key) {
+  if (!entity.paths) entity.paths = { models: [], claws: [], sprites: [], sounds: [] }
+  if (!Array.isArray(entity.paths[key])) entity.paths[key] = []
+  return entity.paths[key]
+}
+
+function pushNormalizedPath(list, value) {
+  const normalized = normalizePath ? normalizePath(value) : (value ? String(value).trim().toLowerCase() : '')
+  if (!normalized) return
+  if (!list.includes(normalized)) list.push(normalized)
+}
+
 export function createEmptyEntity() {
-  // TODO: refine default stats and meta tracking for parsed entities
   return {
     type: '',
     name: '',
@@ -30,14 +57,62 @@ export function createEmptyEntity() {
 }
 
 export function parseSprites(line, entity) {
-  // TODO: detectar sprites y agregarlos a entity.paths.sprites
+  if (!line || !entity) return entity
+  const target = ensurePathArray(entity, 'sprites')
+  let match
+  while ((match = SPRITE_REGEX.exec(line)) !== null) {
+    pushNormalizedPath(target, match[1])
+  }
+  return entity
 }
 
 export function parseSounds(line, entity) {
-  // TODO: detectar sonidos y agregarlos a entity.paths.sounds
+  if (!line || !entity) return entity
+  const target = ensurePathArray(entity, 'sounds')
+  let match
+  while ((match = SOUND_REGEX.exec(line)) !== null) {
+    pushNormalizedPath(target, match[1])
+  }
+  return entity
 }
 
 export function parseAbilities(body, entity) {
-  // TODO: detectar set_user_health / set_user_armor / set_user_gravity / etc.
-  // Guardar en entity.abilities
+  if (!body || !entity) return entity
+  const abilities = ensureAbilities(entity)
+  const meta = ensureMeta(entity)
+
+  for (const pattern of ABILITY_PATTERNS) {
+    pattern.regex.lastIndex = 0
+    let match
+    while ((match = pattern.regex.exec(body)) !== null) {
+      const value = pattern.capture === false ? null : (match[1] ? match[1].trim() : null)
+      const record = {
+        type: 'abilityDetected',
+        fn: pattern.fn,
+        effect: pattern.effect,
+        value
+      }
+      abilities.push({ effect: pattern.effect, fn: pattern.fn, value })
+      meta.extraCalls.push({
+        ...record,
+        kind: 'ability',
+        args: value ? [value] : [],
+        resolved: Boolean(value),
+        dynamic: false,
+        resolvedFrom: ['abilityHeuristic']
+      })
+    }
+  }
+
+  return entity
+}
+
+export default {
+  createEmptyEntity,
+  parseSprites,
+  parseSounds,
+  parseAbilities,
+  parseSMAEntities,
+  normalizeName,
+  normalizePath
 }

--- a/src/renderer/components/ModelPreview.tsx
+++ b/src/renderer/components/ModelPreview.tsx
@@ -1,8 +1,114 @@
-import * as THREE from "three"
+import { useEffect, useRef, useState } from 'react'
+import * as THREE from 'three'
 
-console.log('[renderer] ModelPreview stub loaded')
-
-export function ModelPreview({ path }: { path: string }) {
-  // TODO: usar Three.js para mostrar .mdl
-  return <div>Model preview placeholder for {path}</div>
+type ModelPreviewProps = {
+  path: string
+  className?: string
 }
+
+function buildTextureUrl(path: string) {
+  if (!path) return null
+  const normalized = path.replace(/\\/g, '/').toLowerCase()
+  return `zpb://models/${normalized.replace(/\.mdl$/i, '.png')}`
+}
+
+export function ModelPreview({ path, className }: ModelPreviewProps) {
+  const mountRef = useRef<HTMLDivElement | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const container = mountRef.current
+    if (!container) return undefined
+
+    const width = container.clientWidth || 240
+    const height = container.clientHeight || 200
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(0x111111)
+    const camera = new THREE.PerspectiveCamera(35, width / height, 0.1, 100)
+    camera.position.set(0, 0, 3)
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    renderer.setSize(width, height)
+    renderer.setPixelRatio(window.devicePixelRatio || 1)
+    container.appendChild(renderer.domElement)
+
+    const hemi = new THREE.HemisphereLight(0xffffff, 0x222222, 1.1)
+    scene.add(hemi)
+
+    const group = new THREE.Group()
+    scene.add(group)
+
+    let frame = 0
+    const animate = () => {
+      frame = requestAnimationFrame(animate)
+      group.rotation.y += 0.01
+      renderer.render(scene, camera)
+    }
+
+    const cleanup = () => {
+      cancelAnimationFrame(frame)
+      group.clear()
+      renderer.dispose()
+      if (renderer.domElement && renderer.domElement.parentNode === container) {
+        container.removeChild(renderer.domElement)
+      }
+    }
+
+    const textureUrl = buildTextureUrl(path)
+    if (textureUrl) {
+      const loader = new THREE.TextureLoader()
+      loader.load(
+        textureUrl,
+        (texture) => {
+          const geometry = new THREE.PlaneGeometry(1.5, 1.5)
+          const material = new THREE.MeshBasicMaterial({ map: texture, transparent: true })
+          const mesh = new THREE.Mesh(geometry, material)
+          group.add(mesh)
+          setError(null)
+          animate()
+        },
+        undefined,
+        () => {
+          const geometry = new THREE.BoxGeometry(1.2, 1.2, 1.2)
+          const material = new THREE.MeshStandardMaterial({ color: 0x1f2937, metalness: 0.1, roughness: 0.7 })
+          const mesh = new THREE.Mesh(geometry, material)
+          group.add(mesh)
+          setError('Vista previa no disponible, usando representación genérica.')
+          animate()
+        }
+      )
+    } else {
+      const geometry = new THREE.BoxGeometry(1.2, 1.2, 1.2)
+      const material = new THREE.MeshStandardMaterial({ color: 0x1f2937, metalness: 0.1, roughness: 0.7 })
+      const mesh = new THREE.Mesh(geometry, material)
+      group.add(mesh)
+      setError('Ruta de modelo no proporcionada.')
+      animate()
+    }
+
+    return cleanup
+  }, [path])
+
+  return (
+    <div className={className} style={{ position: 'relative' }}>
+      <div ref={mountRef} style={{ width: '100%', height: '200px' }} />
+      {error && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 8,
+            background: 'rgba(17, 24, 39, 0.85)',
+            color: '#f9fafb',
+            borderRadius: 8,
+            fontSize: 12,
+            padding: '6px 8px'
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ModelPreview

--- a/src/renderer/components/SoundPreview.tsx
+++ b/src/renderer/components/SoundPreview.tsx
@@ -1,5 +1,42 @@
-console.log('[renderer] SoundPreview stub loaded')
+import { useMemo, useState } from 'react'
 
-export function SoundPreview({ path }: { path: string }) {
-  return <audio controls src={path}></audio>
+type SoundPreviewProps = {
+  path: string
+  className?: string
 }
+
+function resolveSoundSources(path: string) {
+  if (!path) return []
+  const normalized = path.replace(/\\/g, '/').toLowerCase()
+  return [`zpb://sounds/${normalized}`, `zpb://input/${normalized}`]
+}
+
+export function SoundPreview({ path, className }: SoundPreviewProps) {
+  const [fallbackIndex, setFallbackIndex] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+  const sources = useMemo(() => resolveSoundSources(path), [path])
+
+  const currentSrc = sources[fallbackIndex] || path
+
+  return (
+    <div className={className} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <audio
+        controls
+        src={currentSrc}
+        onError={() => {
+          if (fallbackIndex + 1 < sources.length) {
+            setFallbackIndex(fallbackIndex + 1)
+            setError(null)
+          } else {
+            setError('No se pudo cargar el sonido.')
+          }
+        }}
+      >
+        Tu navegador no soporta audio embebido.
+      </audio>
+      {error && <span style={{ fontSize: 12, color: '#f87171' }}>{error}</span>}
+    </div>
+  )
+}
+
+export default SoundPreview

--- a/src/renderer/components/SpritePreview.tsx
+++ b/src/renderer/components/SpritePreview.tsx
@@ -1,6 +1,69 @@
-console.log('[renderer] SpritePreview stub loaded')
+import { useEffect, useRef, useState } from 'react'
 
-export function SpritePreview({ path }: { path: string }) {
-  // TODO: renderizar .spr en canvas
-  return <div>Sprite preview placeholder for {path}</div>
+type SpritePreviewProps = {
+  path: string
+  className?: string
 }
+
+function buildSpritePreviewUrl(path: string) {
+  if (!path) return null
+  const normalized = path.replace(/\\/g, '/').toLowerCase()
+  return `zpb://sprites/${normalized.replace(/\.spr$/i, '.png')}`
+}
+
+export function SpritePreview({ path, className }: SpritePreviewProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const url = buildSpritePreviewUrl(path)
+    if (!url) {
+      setError('Ruta de sprite no proporcionada.')
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      return
+    }
+
+    const img = new Image()
+    img.onload = () => {
+      canvas.width = img.width
+      canvas.height = img.height
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.drawImage(img, 0, 0)
+      setError(null)
+    }
+    img.onerror = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      setError('No se pudo cargar la vista previa del sprite.')
+    }
+    img.src = url
+  }, [path])
+
+  return (
+    <div className={className} style={{ position: 'relative', width: 'fit-content' }}>
+      <canvas ref={canvasRef} style={{ imageRendering: 'pixelated', background: '#111827', borderRadius: 8 }} />
+      {error && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 4,
+            background: 'rgba(17, 24, 39, 0.85)',
+            color: '#f9fafb',
+            padding: '4px 6px',
+            borderRadius: 6,
+            fontSize: 12
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SpritePreview

--- a/src/utils/file-scanner.js
+++ b/src/utils/file-scanner.js
@@ -1,6 +1,52 @@
-console.log('[utils] File scanner stub loaded')
+import fs from 'fs/promises'
+import path from 'path'
+
+const MODEL_EXTENSIONS = new Set(['.mdl'])
+const SPRITE_EXTENSIONS = new Set(['.spr'])
+const SOUND_EXTENSIONS = new Set(['.wav', '.mp3'])
+
+function shouldCollect(filePath) {
+  const ext = path.extname(filePath).toLowerCase()
+  if (MODEL_EXTENSIONS.has(ext)) return 'models'
+  if (SPRITE_EXTENSIONS.has(ext)) return 'sprites'
+  if (SOUND_EXTENSIONS.has(ext)) return 'sounds'
+  return null
+}
+
+async function walkDir(dir, base, results) {
+  let entries
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return
+    throw err
+  }
+
+  for (const entry of entries) {
+    const absPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      await walkDir(absPath, base, results)
+      continue
+    }
+
+    const kind = shouldCollect(absPath)
+    if (!kind) continue
+
+    const relPath = path.relative(base, absPath).replace(/\\/g, '/').toLowerCase()
+    if (!results[kind].includes(relPath)) {
+      results[kind].push(relPath)
+    }
+  }
+}
 
 export async function scanResources(baseDir) {
-  // TODO: recorrer input/** y devolver { models: [], sprites: [], sounds: [] }
-  return { models: [], sprites: [], sounds: [] }
+  const normalizedBase = baseDir ? path.resolve(baseDir) : path.resolve(process.cwd(), 'input')
+  const results = { models: [], sprites: [], sounds: [] }
+  await walkDir(normalizedBase, normalizedBase, results)
+  results.models.sort()
+  results.sprites.sort()
+  results.sounds.sort()
+  return results
 }
+
+export default { scanResources }


### PR DESCRIPTION
## Summary
- add a recursive resource scanner that normalizes models, sprites and sounds under input/
- upgrade the SMA parser helpers to surface sprite/sound paths and ability heuristics
- create richer renderer previews for models, sprites and sounds using Three.js/canvas fallbacks
- replace the smoke test stub with a parser-driven report that highlights counts, pseudo classes and missing assets

## Testing
- `npm run build`
- `node scripts/smoke-parse.js`


------
https://chatgpt.com/codex/tasks/task_e_68cecab921408322be1b5e04198980ae